### PR TITLE
feat: add support for struct type

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,6 +13,9 @@ FROM ${BASE_IMAGE} AS packages
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
+RUN sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list
+RUN sed -i s/stretch-updates/stretch/g /etc/apt/sources.list
 RUN apt-get update && apt-get upgrade -y && \
   apt-get install -y \
   build-essential gdb less libffi-dev valgrind \

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         # Windows isn't working right now: https://github.com/caketop/python-starlark-go/issues/4
         os: [ubuntu-latest, macos-latest]
-        cibw_python: ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
+        cibw_python: ["cp37-*", "cp38-*", "cp39-*", "cp310-*"]
         cibw_arch: ["i686", "x86_64", "aarch64", "arm64"]
         include:
           - cibw_arch: arm64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         experimental: [false]
         include:
-          - python-version: '3.12-dev'
+          - python-version: '3.10-dev'
             # sets continue-on-error automatically
             experimental: true
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/caketop/python-starlark-go
 
 go 1.20
 
-require go.starlark.net v0.0.0-20230302034142-4b1e35fe2254
+require go.starlark.net v0.0.0-20240123142251-f86470692795
 
 require golang.org/x/sys v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ go.starlark.net v0.0.0-20230128213706-3f75dec8e403 h1:jPeC7Exc+m8OBJUlWbBLh0O5UZ
 go.starlark.net v0.0.0-20230128213706-3f75dec8e403/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=
 go.starlark.net v0.0.0-20230302034142-4b1e35fe2254 h1:Ss6D3hLXTM0KobyBYEAygXzFfGcjnmfEJOBgSbemCtg=
 go.starlark.net v0.0.0-20230302034142-4b1e35fe2254/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=
+go.starlark.net v0.0.0-20240123142251-f86470692795 h1:LmbG8Pq7KDGkglKVn8VpZOZj6vb9b8nKEGcg9l03epM=
+go.starlark.net v0.0.0-20240123142251-f86470692795/go.mod h1:LcLNIzVOMp4oV+uusnpk+VU+SzXaJakUuBjoCSWH5dM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/python_object.go
+++ b/python_object.go
@@ -18,6 +18,7 @@ import (
 
 	"go.starlark.net/resolve"
 	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
 )
 
 type StarlarkState struct {
@@ -70,7 +71,9 @@ func Starlark_new(pytype *C.PyTypeObject, args *C.PyObject, kwargs *C.PyObject) 
 		return nil
 	}
 
-	state := &StarlarkState{Globals: starlark.StringDict{}, Mutex: sync.RWMutex{}, Print: nil}
+	state := &StarlarkState{Globals: starlark.StringDict{
+		"struct": starlark.NewBuiltin("struct", starlarkstruct.Make),
+	}, Mutex: sync.RWMutex{}, Print: nil}
 	self.handle = C.uintptr_t(cgo.NewHandle(state))
 
 	return self

--- a/starlark.c
+++ b/starlark.c
@@ -226,6 +226,8 @@ PyDoc_STRVAR(
     "<https://pkg.go.dev/go.starlark.net/starlark#Set>`_\n"
     "* Python :py:obj:`python:tuple` to Starlark `tuple "
     "<https://pkg.go.dev/go.starlark.net/starlark#Tuple>`_\n\n"
+    "* Python :py:obj:`python:SimpleNamespace` to Starlark `struct "
+    "<https://pkg.go.dev/go.starlark.net/starlark#Struct>`_\n\n"
     "For the aggregate types (``dict``, ``list``, ``set``, and ``tuple``,) all keys "
     "and/or values must also be one of the supported types.\n\n"
     "Attempting to set a value of any other Python type will raise a "
@@ -526,6 +528,12 @@ int cgoPyList_Check(PyObject *obj)
 {
   /* Necessary because Cgo can't do macros */
   return PyList_Check(obj);
+}
+
+int cgoPySimpleNamespace_Check(PyObject *obj)
+{
+  /* Necessary because Cgo can't do macros */
+  return PyObject_TypeCheck(obj, &_PyNamespace_Type);
 }
 
 /* Helper to fetch exception classes */

--- a/starlark.h
+++ b/starlark.h
@@ -94,4 +94,6 @@ int cgoPyDict_Check(PyObject *obj);
 
 int cgoPyList_Check(PyObject *obj);
 
+int cgoPySimpleNamespace_Check(PyObject *obj);
+
 #endif /* PYTHON_STARLARK_GO_H */

--- a/starlark.h
+++ b/starlark.h
@@ -7,6 +7,7 @@
 #undef Py_LIMITED_API
 #include <Python.h>
 
+
 /* Starlark object */
 typedef struct Starlark {
   PyObject_HEAD uintptr_t handle;

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -19,13 +19,14 @@ def fibonacci(n):
 
 def test_recursion():
     s = Starlark()
-    s.exec(RFIB)
 
     configure_starlark(allow_recursion=False)
+    s.exec(RFIB)
     with pytest.raises(EvalError):
         s.eval("fibonacci(5)")
 
     configure_starlark(allow_recursion=True)
+    s.exec(RFIB)
     assert s.eval("fibonacci(5)") == [0, 1, 1, 2, 3]
     assert s.eval("fibonacci(10)") == [0, 1, 1, 2, 3, 5, 8, 13, 21, 34]
 

--- a/tests/test_get_globals.py
+++ b/tests/test_get_globals.py
@@ -1,10 +1,11 @@
 import pytest
+from types import SimpleNamespace
 
 from starlark_go import Starlark, configure_starlark
 from starlark_go.errors import ResolveError
 
-NESTED = [{"one": (1, 1, 1), "two": [2, {"two": 2222.22}]}, ("a", "b", "c")]
-NESTED_STR = '[{"one": (1, 1, 1), "two": [2, {"two": 2222.22}]}, ("a", "b", "c")]'
+NESTED = [{"one": (1, 1, 1), "two": [2, {"two": 2222.22}]}, ("a", "b", "c"), SimpleNamespace(c=3, d="la reponse d")]
+NESTED_STR = '[{"one": (1, 1, 1), "two": [2, {"two": 2222.22}]}, ("a", "b", "c"), struct(c=3, d="la reponse d")]'
 
 
 def test_int():
@@ -118,6 +119,15 @@ def test_tuple():
     assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), tuple)
     assert s.get("x") == (13, 37)
+
+def test_struct():
+    s = Starlark()
+
+    s.exec("x = struct(c=3, d=\"la reponse d\")")
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
+    assert isinstance(s.get("x"), SimpleNamespace)
+    assert s.get("x") == SimpleNamespace(c=3, d="la reponse d")
 
 
 def test_nested():

--- a/tests/test_get_globals.py
+++ b/tests/test_get_globals.py
@@ -11,15 +11,15 @@ def test_int():
     s = Starlark()
 
     s.exec("x = 7")
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), int)
     assert s.get("x") == 7
 
     # too big to fit in 64 bits
     s.exec("y = 10000000000000000000")
-    assert len(s.globals()) == 2
-    assert sorted(s.globals()) == ["x", "y"]
+    assert len(s.globals()) == 3
+    assert sorted(s.globals()) == ["struct", "x", "y"]
     assert isinstance(s.get("x"), int)
     assert isinstance(s.get("y"), int)
     assert s.get("x") == 7
@@ -30,8 +30,8 @@ def test_float():
     s = Starlark()
 
     s.exec("x = 7.7")
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), float)
     assert s.get("x") == 7.7
 
@@ -40,8 +40,8 @@ def test_bool():
     s = Starlark()
 
     s.exec("x = True")
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), bool)
     assert s.get("x") is True
 
@@ -50,8 +50,8 @@ def test_none():
     s = Starlark()
 
     s.exec("x = None")
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert s.get("x") is None
 
 
@@ -59,8 +59,8 @@ def test_str():
     s = Starlark()
 
     s.exec('x = "True"')
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), str)
     assert s.get("x") == "True"
 
@@ -69,8 +69,8 @@ def test_list():
     s = Starlark()
 
     s.exec('x = [4, 2, 0, "go"]')
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), list)
     assert s.get("x") == [4, 2, 0, "go"]
 
@@ -79,8 +79,8 @@ def test_dict():
     s = Starlark()
 
     s.exec('x = {"lamb": "little", "pickles": 3}')
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), dict)
     assert s.get("x") == {"lamb": "little", "pickles": 3}
 
@@ -94,8 +94,8 @@ def test_set():
 
     configure_starlark(allow_set=True)
     s.exec("x = set((1, 2, 3))")
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), set)
     assert s.get("x") == set((1, 2, 3))
 
@@ -104,8 +104,8 @@ def test_bytes():
     s = Starlark()
 
     s.exec("x = b'dead0000beef'")
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), bytes)
     assert s.get("x") == b"dead0000beef"
 
@@ -114,8 +114,8 @@ def test_tuple():
     s = Starlark()
 
     s.exec("x = (13, 37)")
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), tuple)
     assert s.get("x") == (13, 37)
 
@@ -124,6 +124,6 @@ def test_nested():
     s = Starlark()
 
     s.exec(f"x = {NESTED_STR}")
-    assert s.globals() == ["x"]
-    assert len(s.globals()) == 1
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert s.get("x") == NESTED

--- a/tests/test_pop_global.py
+++ b/tests/test_pop_global.py
@@ -6,16 +6,16 @@ from starlark_go import Starlark
 def test_pop_global():
     s = Starlark(globals={"a": 1, "b": 2, "c": 3})
 
-    assert sorted(s.globals()) == ["a", "b", "c"]
+    assert sorted(s.globals()) == ["a", "b", "c", "struct"]
 
     b = s.pop("b")
 
     assert b == 2
-    assert sorted(s.globals()) == ["a", "c"]
+    assert sorted(s.globals()) == ["a", "c", "struct"]
 
     with pytest.raises(KeyError):
         s.pop("b")
 
     assert s.pop("b", None) is None
 
-    assert sorted(s.globals()) == ["a", "c"]
+    assert sorted(s.globals()) == ["a", "c", "struct"]

--- a/tests/test_set_globals.py
+++ b/tests/test_set_globals.py
@@ -1,8 +1,9 @@
 import pytest
+from types import SimpleNamespace
 
 from starlark_go import Starlark
 
-NESTED = [{"one": (1, 1, 1), "two": [2, {"two": 2222.22}]}, ("a", "b", "c")]
+NESTED = [{"one": (1, 1, 1), "two": [2, {"two": 2222.22}]}, ("a", "b", "c"), SimpleNamespace(c=3, d="la reponse d")]
 
 
 def test_set_globals():
@@ -158,10 +159,20 @@ def test_tuple():
     assert s.get("x") == (13, 37)
 
 
+def test_struct():
+    s = Starlark()
+
+    s.set(x=SimpleNamespace(c=3, d="la reponse d"))
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
+    assert isinstance(s.get("x"), SimpleNamespace)
+    assert s.get("x") == SimpleNamespace(c=3, d="la reponse d")
+
+
 def test_nested():
     s = Starlark()
 
     s.set(x=NESTED)
-    assert s.globals() == ["x"]
-    assert len(s.globals()) == 1
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert s.get("x") == NESTED

--- a/tests/test_set_globals.py
+++ b/tests/test_set_globals.py
@@ -9,22 +9,24 @@ def test_set_globals():
     s = Starlark()
 
     s.set()
-    assert len(s.globals()) == 0
+    assert len(s.globals()) == 1
+    assert s.globals() == ["struct"]
 
     s.set(x=1)
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
 
     s.set(x=1, y=[2], z={3: 3})
-    assert len(s.globals()) == 3
-    assert sorted(s.globals()) == ["x", "y", "z"]
+    assert len(s.globals()) == 4
+    assert sorted(s.globals()) == ["struct", "x", "y", "z"]
 
     s2 = Starlark(globals={"x": 1, "y": 2, "z": 3})
-    assert len(s2.globals()) == 3
-    assert sorted(s2.globals()) == ["x", "y", "z"]
+    assert len(s2.globals()) == 4
+    assert sorted(s2.globals()) == ["struct", "x", "y", "z"]
 
     s3 = Starlark(globals={})
-    assert len(s3.globals()) == 0
+    assert len(s3.globals()) == 1
+    assert s3.globals() == ["struct"]
 
     with pytest.raises(TypeError):
         Starlark(globals=True)  # type: ignore
@@ -46,16 +48,16 @@ def test_int():
     s = Starlark()
 
     s.set(x=7)
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), int)
     assert s.get("x") == 7
     assert s.eval("x + 1") == 8
 
     # too big to fit in 64 bits
     s.set(y=10000000000000000000)
-    assert len(s.globals()) == 2
-    assert sorted(s.globals()) == ["x", "y"]
+    assert len(s.globals()) == 3
+    assert sorted(s.globals()) == ["struct", "x", "y"]
     assert isinstance(s.get("x"), int)
     assert isinstance(s.get("y"), int)
     assert s.get("x") == 7
@@ -67,8 +69,8 @@ def test_float():
     s = Starlark()
 
     s.set(x=7.7)
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), float)
     assert s.get("x") == 7.7
     assert s.eval("int(x)") == 7
@@ -79,8 +81,8 @@ def test_bool():
     s = Starlark()
 
     s.set(x=True)
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), bool)
     assert s.get("x") is True
     assert s.eval("not x") is False
@@ -90,8 +92,8 @@ def test_none():
     s = Starlark()
 
     s.set(x=None)
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert s.get("x") is None
 
 
@@ -99,8 +101,8 @@ def test_str():
     s = Starlark()
 
     s.set(x="True")
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), str)
     assert s.get("x") == "True"
     assert s.eval("x + 'True'") == "TrueTrue"
@@ -110,8 +112,8 @@ def test_list():
     s = Starlark()
 
     s.set(x=[4, 2, 0, "go"])
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), list)
     assert s.get("x") == [4, 2, 0, "go"]
 
@@ -120,8 +122,8 @@ def test_dict():
     s = Starlark()
 
     s.set(x={"lamb": "little", "pickles": 3})
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), dict)
     assert s.get("x") == {"lamb": "little", "pickles": 3}
 
@@ -130,8 +132,8 @@ def test_set():
     s = Starlark()
 
     s.set(x=set((1, 2, 3)))
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), set)
     assert s.get("x") == set((1, 2, 3))
 
@@ -140,8 +142,8 @@ def test_bytes():
     s = Starlark()
 
     s.set(x=b"dead0000beef")
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), bytes)
     assert s.get("x") == b"dead0000beef"
 
@@ -150,8 +152,8 @@ def test_tuple():
     s = Starlark()
 
     s.set(x=(13, 37))
-    assert len(s.globals()) == 1
-    assert s.globals() == ["x"]
+    assert len(s.globals()) == 2
+    assert sorted(s.globals()) == ["struct", "x"]
     assert isinstance(s.get("x"), tuple)
     assert s.get("x") == (13, 37)
 

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -1,10 +1,11 @@
 import pytest
+from types import SimpleNamespace
 
 from starlark_go import Starlark, configure_starlark
 from starlark_go.errors import ResolveError
 
-NESTED = [{"one": (1, 1, 1), "two": [2, {"two": 2222.22}]}, ("a", "b", "c")]
-NESTED_STR = '[{"one": (1, 1, 1), "two": [2, {"two": 2222.22}]}, ("a", "b", "c")]'
+NESTED = [{"one": (1, 1, 1), "two": [2, {"two": 2222.22}]}, ("a", "b", "c"), SimpleNamespace(foo=1, bar="bar-str")]
+NESTED_STR = '[{"one": (1, 1, 1), "two": [2, {"two": 2222.22}]}, ("a", "b", "c"), struct(foo=1, bar="bar-str")]'
 
 
 def test_int():
@@ -182,3 +183,19 @@ def test_nested():
 
     x = s.eval(NESTED_STR)
     assert x == NESTED
+
+
+def test_struct():
+    s = Starlark()
+
+    x = s.eval("struct(a=1, b=2)")
+    assert isinstance(x, SimpleNamespace)
+    assert x == SimpleNamespace(a=1, b=2)
+
+    x = s.eval("struct(a=1, b=2)", convert=True)
+    assert isinstance(x, SimpleNamespace)
+    assert x == SimpleNamespace(a=1, b=2)
+
+    x = s.eval("struct(a=1, b=2)", convert=False)
+    assert isinstance(x, str)
+    assert x == "struct(a = 1, b = 2)"


### PR DESCRIPTION
This is adding support for Starlark struct type: https://github.com/google/starlark-go/tree/master/starlarkstruct

It binds in both directions to Python SimpleNamespace. This is also using the latest release of `starlark-go`.